### PR TITLE
Refactor header into partial with CSS and JS

### DIFF
--- a/header.css
+++ b/header.css
@@ -1,0 +1,63 @@
+body {
+    margin: 0;
+    font-family: 'Georgia', serif;
+    /*background: url('images/background.png') repeat;*/
+}
+
+/* Header bar styling */
+.header-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 65px; /* height of header */
+    background: url('icons/header_bar.webp') repeat-x center center;
+    background-size: auto 100%; /* makes image height match the header */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+/* Centered content within the bar */
+.header-content {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 30px;
+    box-sizing: border-box;
+}
+
+/* Title in the center */
+.header-title {
+    font-size: 2rem;
+    color: #3a2a18;
+    text-shadow: 1px 1px 2px rgba(0,0,0,0.3);
+    margin: 0;
+}
+
+/* Icon buttons */
+.icon-button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    margin: 0 5px;
+}
+
+.icon-button img {
+    height: 52px; /* Size your icon */
+    width: 52px;
+    transition: transform 0.2s ease;
+}
+
+.icon-button img:hover {
+    transform: scale(1.1);
+}
+
+.header-icons.left,
+.header-icons.right {
+    display: flex;
+    align-items: center;
+}

--- a/header.html
+++ b/header.html
@@ -1,123 +1,29 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Mirrin's Gate</title>
-  <link rel="stylesheet" href="style.css">
-</head>
-<body>
-  
-  <!-- Header Bar -->
-  <header class="header-bar">
-    <div class="header-content">
-      <!-- Left Icons -->
-      <div class="header-icons left">
-        <button class="icon-button" onclick="window.location.href='index.html'">
-          <img src="icons/icon_back.webp" alt="Back">
-        </button>
-      </div>
-
-      <!-- Title -->
-      <h1 class="header-title">Mirrin's Gate</h1>
-
-      <!-- Right Icons -->
-      <div class="header-icons right">
-        <button class="icon-button" onclick="window.location.href='town.html'">
-          <img src="icons/icon_town.webp" alt="Town">
-        </button>
-        <button class="icon-button" onclick="window.location.href='world.html'">
-          <img src="icons/icon_world.webp" alt="World Map">
-        </button>
-        <button class="icon-button" onclick="window.location.href='journal.html'">
-          <img src="icons/icon_journal.webp" alt="Journal">
-        </button>
-        <button class="icon-button">
-          <img id="musicToggle" src="icons/icon_unmute.webp" alt="Toggle Music">
-        </button>
-      </div>
-
+<header class="header-bar">
+  <div class="header-content">
+    <!-- Left Icons -->
+    <div class="header-icons left">
+      <button class="icon-button" onclick="window.location.href='index.html'">
+        <img src="icons/icon_back.webp" alt="Back">
+      </button>
     </div>
-  </header>
 
-  <script>
-    // Music toggle demo
-    const musicButton = document.getElementById('musicToggle');
-    let musicOn = true;
+    <!-- Title -->
+    <h1 class="header-title">Mirrin's Gate</h1>
 
-    musicButton.addEventListener('click', () => {
-      musicOn = !musicOn;
-      musicButton.src = musicOn ? 'icons/icon_unmute.webp' : 'icons/icon_mute.webp';
-      // Here you would also toggle your game's audio
-    });
-  </script>
-
-<style>
-  body {
-    margin: 0;
-    font-family: 'Georgia', serif;
-    /*background: url('images/background.png') repeat;*/
-  }
-
-  /* Header bar styling */
-  .header-bar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 65px; /* height of header */
-    background: url('icons/header_bar.webp') repeat-x center center;
-    background-size: auto 100%; /* makes image height match the header */
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1000;
-  }
-
-  /* Centered content within the bar */
-  .header-content {
-    width: 100%;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0 30px;
-    box-sizing: border-box;
-  }
-
-  /* Title in the center */
-  .header-title {
-    font-size: 2rem;
-    color: #3a2a18;
-    text-shadow: 1px 1px 2px rgba(0,0,0,0.3);
-    margin: 0;
-  }
-
-  /* Icon buttons */
-  .icon-button {
-    background: none;
-    border: none;
-    cursor: pointer;
-    padding: 0;
-    margin: 0 5px;
-  }
-
-  .icon-button img {
-    height: 52px; /* Size your icon */
-    width: 52px;
-    transition: transform 0.2s ease;
-  }
-
-  .icon-button img:hover {
-    transform: scale(1.1);
-  }
-
-  .header-icons.left,
-  .header-icons.right {
-    display: flex;
-    align-items: center;
-  }
-  </style>
-
-  
-</body>
-</html>
+    <!-- Right Icons -->
+    <div class="header-icons right">
+      <button class="icon-button" onclick="window.location.href='town.html'">
+        <img src="icons/icon_town.webp" alt="Town">
+      </button>
+      <button class="icon-button" onclick="window.location.href='world.html'">
+        <img src="icons/icon_world.webp" alt="World Map">
+      </button>
+      <button class="icon-button" onclick="window.location.href='journal.html'">
+        <img src="icons/icon_journal.webp" alt="Journal">
+      </button>
+      <button class="icon-button">
+        <img id="musicToggle" src="icons/icon_unmute.webp" alt="Toggle Music">
+      </button>
+    </div>
+  </div>
+</header>

--- a/header.js
+++ b/header.js
@@ -1,0 +1,9 @@
+const musicButton = document.getElementById('musicToggle');
+if (musicButton) {
+  let musicOn = true;
+  musicButton.addEventListener('click', () => {
+    musicOn = !musicOn;
+    musicButton.src = musicOn ? 'icons/icon_unmute.webp' : 'icons/icon_mute.webp';
+    // Here you would also toggle your game's audio
+  });
+}

--- a/journal.html
+++ b/journal.html
@@ -18,61 +18,6 @@
       color: #3a2a18;
     }
 
-    /* === HEADER BAR === */
-    .header-bar {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 65px; /* same as town.html */
-      background: url('icons/header_bar.png') repeat-x center center;
-      background-size: auto 100%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      z-index: 1000;
-    }
-
-    .header-content {
-      width: 100%;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 0 30px;
-      box-sizing: border-box;
-    }
-
-    .header-title {
-      font-size: 2rem;
-      color: #3a2a18;
-      text-shadow: 1px 1px 2px rgba(0,0,0,0.3);
-      margin: 0;
-    }
-
-    .icon-button {
-      background: none;
-      border: none;
-      cursor: pointer;
-      padding: 0;
-      margin: 0 5px;
-    }
-
-    .icon-button img {
-      height: 52px;
-      width: 52px;
-      transition: transform 0.2s ease;
-    }
-
-    .icon-button img:hover {
-      transform: scale(1.1);
-    }
-
-    .header-icons.left,
-    .header-icons.right {
-      display: flex;
-      align-items: center;
-    }
-
     /* === JOURNAL LAYOUT === */
     #sidebar {
       position: fixed;
@@ -142,34 +87,7 @@
 </head>
 <body>
   <!-- Fancy Header -->
-  <header class="header-bar">
-    <div class="header-content">
-      <div class="header-icons left">
-        <button class="icon-button" onclick="window.location.href='index.html'">
-          <img src="icons/icon_back.webp" alt="Back">
-        </button>
-      </div>
-
-      <h1 class="header-title">Mirrin's Gate</h1>
-
-
-      <!-- Right Icons -->
-      <div class="header-icons right">
-        <button class="icon-button" onclick="window.location.href='town.html'">
-          <img src="icons/icon_town.webp" alt="Town">
-        </button>
-        <button class="icon-button" onclick="window.location.href='world.html'">
-          <img src="icons/icon_world.webp" alt="World Map">
-        </button>
-        <button class="icon-button" onclick="window.location.href='journal.html'">
-          <img src="icons/icon_journal.webp" alt="Journal">
-        </button>
-        <button class="icon-button">
-          <img id="musicToggle" src="icons/icon_unmute.webp" alt="Toggle Music">
-        </button>
-      </div>
-    </div>
-  </header>
+  <div id="header-container"></div>
 
   <!-- Journal Layout -->
   <div class="journal-container">
@@ -184,14 +102,28 @@
   </div>
 
   <script>
-  // Music toggle
-  const musicButton = document.getElementById('musicToggle');
-  let musicOn = true;
+  function loadHeader() {
+    return fetch('header.html')
+      .then(res => res.text())
+      .then(html => {
+        document.getElementById('header-container').innerHTML = html;
 
-  musicButton.addEventListener('click', () => {
-    musicOn = !musicOn;
-    musicButton.src = musicOn ? 'icons/icon_unmute.webp' : 'icons/icon_mute.webp';
-  });
+        if (!document.querySelector('link[href="header.css"]')) {
+          const link = document.createElement('link');
+          link.rel = 'stylesheet';
+          link.href = 'header.css';
+          document.head.appendChild(link);
+        }
+
+        if (!document.querySelector('script[src="header.js"]')) {
+          const script = document.createElement('script');
+          script.src = 'header.js';
+          document.head.appendChild(script);
+        }
+      });
+  }
+
+  loadHeader();
 
   async function fetchMarkdown(post) {
     // 1️⃣ If inline markdown exists, use it

--- a/town.html
+++ b/town.html
@@ -86,14 +86,31 @@
       }
     }
 
-    // Load header
-    fetch('header.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('header-container').innerHTML = html;
-        headerLoaded = true;
-        maybeReveal();
-      });
+    function loadHeader() {
+      return fetch('header.html')
+        .then(res => res.text())
+        .then(html => {
+          document.getElementById('header-container').innerHTML = html;
+
+          if (!document.querySelector('link[href="header.css"]')) {
+            const link = document.createElement('link');
+            link.rel = 'stylesheet';
+            link.href = 'header.css';
+            document.head.appendChild(link);
+          }
+
+          if (!document.querySelector('script[src="header.js"]')) {
+            const script = document.createElement('script');
+            script.src = 'header.js';
+            document.head.appendChild(script);
+          }
+        });
+    }
+
+    loadHeader().then(() => {
+      headerLoaded = true;
+      maybeReveal();
+    });
 
     // Load assets
     initLoader(

--- a/world.html
+++ b/world.html
@@ -93,10 +93,28 @@
 </div>
 
   <script>
-    // Load header dynamically
-    fetch('header.html')
-      .then(res => res.text())
-      .then(data => document.getElementById('header-container').innerHTML = data);
+    function loadHeader() {
+      return fetch('header.html')
+        .then(res => res.text())
+        .then(html => {
+          document.getElementById('header-container').innerHTML = html;
+
+          if (!document.querySelector('link[href="header.css"]')) {
+            const link = document.createElement('link');
+            link.rel = 'stylesheet';
+            link.href = 'header.css';
+            document.head.appendChild(link);
+          }
+
+          if (!document.querySelector('script[src="header.js"]')) {
+            const script = document.createElement('script');
+            script.src = 'header.js';
+            document.head.appendChild(script);
+          }
+        });
+    }
+
+    loadHeader();
 
     const map = document.getElementById('worldMap');
     const container = document.getElementById('mapContainer');


### PR DESCRIPTION
## Summary
- Replace `header.html` with bare `<header>` element
- Extract header styles into `header.css` and music toggle script into `header.js`
- Load header partial and assets in `town.html`, `world.html`, and `journal.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899b70a9e388329a2c02d1c4ee8d04e